### PR TITLE
Implement conversation management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Um chatbot inteligente construído com Next.js e OpenAI.
 - Sistema de feedback para respostas
 - Tratamento de erros
 - Suporte a Markdown nas respostas
+- Gerenciamento de conversas com histórico
 
 ## Como usar
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,15 +16,30 @@ model Visitor {
   consentimento Boolean
   createdAt    DateTime @default(now())
   messages     Message[]
+  conversations Conversation[]
 }
 
 model Message {
-  id         Int      @id @default(autoincrement())
-  content    String
-  sender     String   // "user" ou "bot"
-  timestamp  DateTime @default(now())
-  visitorId  Int
-  visitor    Visitor  @relation(fields: [visitorId], references: [id])
+  id              String        @id @default(cuid())
+  visitorId       Int
+  visitor         Visitor       @relation(fields: [visitorId], references: [id])
+  conversationId  String
+  conversation    Conversation  @relation(fields: [conversationId], references: [id])
+  role            String
+  content         String
+  createdAt       DateTime      @default(now())
+}
+
+model Conversation {
+  id           String     @id @default(cuid())
+  threadId     String
+  visitorId    Int
+  visitor      Visitor    @relation(fields: [visitorId], references: [id])
+  startedAt    DateTime   @default(now())
+  endedAt      DateTime?
+  duration     Int?
+  status       String     @default("open")
+  messages     Message[]
 }
 
 model User {

--- a/src/app/api/conversations/[conversationId]/end/route.ts
+++ b/src/app/api/conversations/[conversationId]/end/route.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client'
+import { NextResponse } from 'next/server'
+
+const prisma = new PrismaClient()
+export const runtime = 'nodejs'
+
+export async function POST(req: Request, { params }: { params: { conversationId: string } }) {
+  const { conversationId } = params
+  try {
+    const now = new Date()
+    const convo = await prisma.conversation.update({
+      where: { id: conversationId },
+      data: { status: 'closed', endedAt: now }
+    })
+    const duration = Math.floor((now.getTime() - convo.startedAt.getTime()) / 1000)
+    await prisma.conversation.update({ where: { id: conversationId }, data: { duration } })
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return NextResponse.json({ error: 'Falha ao encerrar conversa' }, { status: 500 })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/src/app/api/conversations/[conversationId]/messages/route.ts
+++ b/src/app/api/conversations/[conversationId]/messages/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+import { openai } from '@/server/utils/openai'
+import { assistantId } from '@/server/config/assistant'
+
+const prisma = new PrismaClient()
+export const runtime = 'nodejs'
+
+export async function POST(request: NextRequest, { params }: { params: { conversationId: string } }) {
+  const { conversationId } = params
+  try {
+    const { content } = await request.json()
+    if (!content) return NextResponse.json({ error: 'Conteudo obrigatorio' }, { status: 400 })
+
+    const conversation = await prisma.conversation.findUnique({ where: { id: conversationId } })
+    if (!conversation) return NextResponse.json({ error: 'Conversa nao encontrada' }, { status: 404 })
+
+    await prisma.message.create({
+      data: {
+        role: 'user',
+        content,
+        visitorId: conversation.visitorId,
+        conversationId: conversation.id
+      }
+    })
+
+    await openai.beta.threads.messages.create(conversation.threadId, { role: 'user', content })
+
+    const stream = await openai.beta.threads.runs.createAndStream(conversation.threadId, { assistant_id: assistantId })
+
+    let assistantText = ''
+    stream.on('textDelta', (delta) => { if (delta.value) assistantText += delta.value })
+    stream.on('end', async () => {
+      await prisma.message.create({
+        data: {
+          role: 'assistant',
+          content: assistantText,
+          visitorId: conversation.visitorId,
+          conversationId: conversation.id
+        }
+      })
+      await prisma.$disconnect()
+    })
+    stream.on('error', async () => { await prisma.$disconnect() })
+
+    return new Response(stream.toReadableStream(), {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive'
+      }
+    })
+  } catch (err) {
+    console.error('Erro ao enviar mensagem', err)
+    return NextResponse.json({ error: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { conversationId: string } }) {
+  const { conversationId } = params
+  try {
+    const messages = await prisma.message.findMany({ where: { conversationId }, orderBy: { createdAt: 'asc' } })
+    return NextResponse.json({ messages })
+  } catch (err) {
+    return NextResponse.json({ error: 'Erro ao obter mensagens' }, { status: 500 })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client'
+import { openai } from '@/server/utils/openai'
+import { NextResponse } from 'next/server'
+
+const prisma = new PrismaClient()
+export const runtime = 'nodejs'
+
+export async function POST(req: Request) {
+  try {
+    const { visitorId } = await req.json()
+    if (!visitorId) {
+      return NextResponse.json({ error: 'visitorId obrigatorio' }, { status: 400 })
+    }
+    const thread = await openai.beta.threads.create()
+    const conversation = await prisma.conversation.create({
+      data: {
+        threadId: thread.id,
+        visitorId: Number(visitorId)
+      }
+    })
+    return NextResponse.json({ conversationId: conversation.id, threadId: thread.id })
+  } catch (error) {
+    return NextResponse.json({ error: 'Falha ao criar conversa' }, { status: 500 })
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/src/app/formulario/page.tsx
+++ b/src/app/formulario/page.tsx
@@ -1,21 +1,61 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Form } from '@/client/components/form/Form';
 import Chat from '@/client/components/chat/chat';
 import styles from "./page.module.css";
 
 export default function FormPage() {
-  const [visitorId, setVisitorId] = useState<string | null>(null);
+  const [session, setSession] = useState<{
+    visitorId: string;
+    conversationId: string;
+    threadId: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const vid = localStorage.getItem('visitorId');
+    const cid = localStorage.getItem('conversationId');
+    const tid = localStorage.getItem('threadId');
+    if (vid && cid && tid) {
+      setSession({ visitorId: vid, conversationId: cid, threadId: tid });
+    }
+  }, []);
+
+  const startChat = async (visitorId: string) => {
+    const res = await fetch('/api/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ visitorId })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      localStorage.setItem('visitorId', visitorId);
+      localStorage.setItem('conversationId', data.conversationId);
+      localStorage.setItem('threadId', data.threadId);
+      setSession({ visitorId, conversationId: data.conversationId, threadId: data.threadId });
+    }
+  };
+
+  const handleEnd = () => {
+    localStorage.removeItem('visitorId');
+    localStorage.removeItem('conversationId');
+    localStorage.removeItem('threadId');
+    setSession(null);
+  };
 
   return (
     <div>
-      {!visitorId ? (
-        <Form onSuccess={(id: string) => setVisitorId(id)} />
+      {!session ? (
+        <Form onSuccess={startChat} />
       ) : (
         <main className={styles.main}>
           <div className={styles.container}>
-            <Chat visitorId={visitorId} />
+            <Chat
+              visitorId={session.visitorId}
+              conversationId={session.conversationId}
+              threadId={session.threadId}
+              onEnd={handleEnd}
+            />
           </div>
         </main>
       )}

--- a/src/client/components/chat/chat.module.css
+++ b/src/client/components/chat/chat.module.css
@@ -111,3 +111,14 @@
 .feedbackButtons button:hover {
   opacity: 1;
 }
+
+.endButton {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #dc3545;
+  border: none;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+  align-self: flex-end;
+}


### PR DESCRIPTION
## Summary
- track chat sessions with new `Conversation` model
- add API routes to create, end and message conversations
- wire conversation session handling on the form page
- update chat component to use conversations and allow ending chat
- document conversation feature

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ca3e0458832fae02e7347844b037