### PR TITLE
feat: add quick question shortcuts and update hero instructions

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -5,6 +5,7 @@ import { sendMessage } from '@/server/services/chatService';
 const bodySchema = z.object({
   conversationId: z.string().uuid(),
   content: z.string().min(1),
+  formatDirectives: z.string().optional(),
 });
 
 export async function POST(req: Request) {
@@ -18,10 +19,14 @@ export async function POST(req: Request) {
     );
   }
 
-  const { conversationId, content } = result.data;
+  const { conversationId, content, formatDirectives } = result.data;
 
   try {
-    const assistantText = await sendMessage(conversationId, content);
+    const assistantText = await sendMessage(
+      conversationId,
+      content,
+      formatDirectives
+    );
 
     console.log('Message exchanged on conversation', conversationId);
 

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -69,6 +69,30 @@
   max-width: 380px;
 }
 
+.instructions {
+  text-align: left;
+  max-width: 700px;
+  margin: 0 0 30px;
+}
+
+.instructionsTitle {
+  color: #333333;
+  font-size: clamp(1.2rem, 4vw, 1.5rem);
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.instructionsList {
+  list-style-position: inside;
+  color: #333333;
+  font-size: clamp(1rem, 3.5vw, 1.2rem);
+  padding-left: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .chatButton:hover {
   transform: translateY(-3px);
   box-shadow: 0 7px 25px rgba(0, 82, 155, 0.4);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,10 +32,22 @@ const Home = () => {
         </div>
         
         <p className={styles.welcomeText}>
-          Olá! Sou a Bia, sua assistente virtual da Brancotex. 
-          Posso te ajudar a encontrar a solução perfeita em tintas 
-          para seu projeto.
+          Sou a Bia, uma inteligência artificial em treinamento. Posso
+          cometer erros, mas vou fazer o possível para te ajudar a
+          encontrar as melhores opções para o seu projeto. Se algo
+          parecer impreciso, confirme comigo ou com nossa equipe.
         </p>
+
+        <div className={styles.instructions}>
+          <h2 className={styles.instructionsTitle}>Instruções de uso</h2>
+          <ol className={styles.instructionsList}>
+            <li>Seja específico(a) nas suas perguntas.</li>
+            <li>Faça uma pergunta por vez.</li>
+            <li>
+              Evite compartilhar dados sensíveis (ex.: CPF, senhas).
+            </li>
+          </ol>
+        </div>
         
         <button
           className={styles.chatButton}

--- a/src/client/components/chat/chat.module.css
+++ b/src/client/components/chat/chat.module.css
@@ -58,6 +58,43 @@
   gap: 16px;
 }
 
+.quickQuestionsSection {
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #eee;
+}
+
+.quickQuestionsTitle {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.quickQuestionsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quickQuestionButton {
+  background-color: #eef1f4;
+  border: none;
+  border-radius: 20px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.quickQuestionButton:hover:enabled {
+  background-color: #d9dde1;
+}
+
+.quickQuestionButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .reloadIcon {
   cursor: pointer;
   font-size: 1.5rem;

--- a/src/client/components/form/Form.tsx
+++ b/src/client/components/form/Form.tsx
@@ -196,8 +196,9 @@ export const Form: React.FC<FormProps> = ({ onSuccess }) => {
       // Salva os dados do novo visitante
       localStorage.setItem("visitorData", JSON.stringify(visitorData));
       onSuccess?.(result.visitorId);
-    } catch (err: any) {
-      toast.error(err.message || "Erro ao enviar dados");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro ao enviar dados";
+      toast.error(message);
     }
   };
 

--- a/src/client/hooks/useCnpjApi.ts
+++ b/src/client/hooks/useCnpjApi.ts
@@ -1,6 +1,12 @@
 
 import { useState, useCallback } from 'react';
-import { FieldValues, UseFormSetValue, UseFormTrigger, Path } from 'react-hook-form';
+import {
+  FieldValues,
+  UseFormSetValue,
+  UseFormTrigger,
+  Path,
+  PathValue,
+} from 'react-hook-form';
 import toast from 'react-hot-toast';
 
 export const useCnpjApi = <T extends FieldValues>(
@@ -47,7 +53,11 @@ export const useCnpjApi = <T extends FieldValues>(
           fetchBrasilApi(),
           fetchCnpjWs(),
         ]);
-        setValue('empresa' as Path<T>, nomeFantasia as any, { shouldValidate: true });
+        setValue(
+          'empresa' as Path<T>,
+          nomeFantasia as PathValue<T, Path<T>>,
+          { shouldValidate: true }
+        );
         trigger('empresa' as Path<T>);
         toast.success("Dados da empresa carregados!");
       } catch (err) {

--- a/src/data/quickQuestions.ts
+++ b/src/data/quickQuestions.ts
@@ -1,0 +1,109 @@
+export type QuickQuestion = {
+  id: string;
+  label: string;          // texto no botão
+  userMessage: string;    // o que aparece como pergunta do usuário
+  formatDirectives: string; // molde/estrutura que será anexado à mensagem enviada à OpenAI
+};
+
+export const quickQuestions: QuickQuestion[] = [
+  {
+    id: "produtos",
+    label: "Quero conhecer as linhas de produtos",
+    userMessage: "Quais são as linhas de produtos de tintas e para quais aplicações cada uma é indicada?",
+    formatDirectives: `
+Responda seguindo exatamente este formato em Markdown:
+
+**Resumo (1 frase)**
+- [frase curta]
+
+**Principais linhas (tabela)**
+- Linha | Aplicação principal | Materiais compatíveis | Observações
+
+**Como escolher (3 critérios)**
+- Critério 1
+- Critério 2
+- Critério 3
+
+**Próximos passos**
+- Faça 2 perguntas para entender melhor a necessidade do usuário.
+    `
+  },
+  {
+    id: "sublimacao",
+    label: "Dúvidas de sublimação (tecido e prensa)",
+    userMessage: "Quais parâmetros e cuidados devo usar para sublimação em tecido poliéster?",
+    formatDirectives: `
+Use este formato em Markdown:
+
+**Pré-requisitos**
+- Tecido, papel, tinta, impressora, prensa
+
+**Parâmetros sugeridos**
+- Temperatura (°C), tempo (s), pressão (leve/média/alta) e variações por tecido
+
+**Checklist de qualidade**
+- Itens objetivos a verificar
+
+**Erros comuns e como corrigir**
+- Erro -> Correção
+
+**Perguntas de confirmação**
+- Liste 2 a 3 informações que você ainda precisa (tecido, gramatura, equipamento, etc.)
+    `
+  },
+  {
+    id: "cores-apagadas",
+    label: "Minhas cores estão apagadas",
+    userMessage: "Minhas impressões estão saindo com cores fracas/apagadas. O que verificar?",
+    formatDirectives: `
+Responder em Markdown com:
+
+**Diagnóstico rápido (passo a passo)**
+1. Verificar perfil ICC/driver
+2. Conferir papel/mídia
+3. Checar temperatura/tempo/pressão
+4. Manutenção da impressora (limpeza de cabeças, alinhamento)
+
+**Causas prováveis x Ações**
+- Causa -> Ação recomendada
+
+**Teste controlado**
+- Procedimento de teste simples para isolar o problema
+    `
+  },
+  {
+    id: "indicacao-material",
+    label: "Qual tinta para meu material?",
+    userMessage: "Qual tinta você recomenda para o meu material?",
+    formatDirectives: `
+Formate assim:
+
+**O que preciso saber**
+- Material exato (algodão, poliéster, cerâmica, metal, vidro, PVC, etc.)
+- Método de aplicação/transferência
+- Exigências de durabilidade/acabamento
+
+**Recomendações por cenário**
+- Material: [nome] -> Tinta/processo sugerido + prós/contras + observações
+
+**Avisos**
+- Compatibilidade e cuidados importantes
+    `
+  },
+  {
+    id: "vendedor",
+    label: "Falar com um vendedor",
+    userMessage: "Quero falar com um vendedor.",
+    formatDirectives: `
+Objetivo: Coletar dados de contato em 3 linhas.
+
+**Encaminhamento**
+- Solicite cidade/UF e um contato (e-mail ou WhatsApp).
+- Informe que o time comercial retornará.
+- Não peça dados sensíveis.
+
+**Estrutura**
+- 1 frase de confirmação + 2 itens do que precisa para abrir o chamado.
+    `
+  }
+];

--- a/src/server/services/chatService.ts
+++ b/src/server/services/chatService.ts
@@ -30,7 +30,11 @@ export async function startConversation(data: VisitorData) {
   return { conversationId: conversation.id };
 }
 
-export async function sendMessage(conversationId: string, content: string) {
+export async function sendMessage(
+  conversationId: string,
+  content: string,
+  formatDirectives?: string
+) {
   const conversation = await prisma.conversation.findUnique({ where: { id: conversationId } });
   if (!conversation || conversation.status !== 'OPEN') {
     throw new Error('Conversa não encontrada ou encerrada');
@@ -50,7 +54,11 @@ export async function sendMessage(conversationId: string, content: string) {
     await prisma.conversation.update({ where: { id: conversationId }, data: { threadId } });
   }
 
-  const assistantText = await getAssistantResponse(threadId, content);
+  const enrichedContent = formatDirectives
+    ? `${content}\n\n[INSTRUÇÕES DE FORMATO – SIGA ESTRITAMENTE]\n${formatDirectives}`
+    : content;
+
+  const assistantText = await getAssistantResponse(threadId, enrichedContent);
 
   await prisma.message.create({
     data: {


### PR DESCRIPTION
## Contexto
- informar sobre limitações da Bia e orientar uso
- facilitar início de conversa com perguntas rápidas

## O que mudou
- atualiza texto inicial e adiciona bloco de instruções na landing
- cria conjunto de perguntas rápidas com diretivas de formato
- envia diretivas ao backend para estruturar respostas
- exibe botões de perguntas rápidas e desabilita durante envio

## Como testar
1. `npm run dev`
2. abrir `http://localhost:3000` e conferir aviso e instruções no hero
3. iniciar atendimento e escolher uma pergunta rápida
4. verificar que a pergunta aparece no chat e a resposta segue o formato proposto
5. enviar uma mensagem manual e conferir fluxo normal


------
https://chatgpt.com/codex/tasks/task_e_6897a1f520b8832f9bd38b262067b7f3